### PR TITLE
Secure Key Management

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,9 +1,32 @@
+##
+# Copyright 2016 Canonical Ltd.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+##
+
 run:
-  description: "Run an arbitrary command"
-  params:
-    command:
-      description: "The command to execute."
-      type: string
-      default: ""
-  required:
-    - command
+    description: "Run an arbitrary command"
+    params:
+        command:
+            description: "The command to execute."
+            type: string
+            default: ""
+    required:
+        - command
+generate-ssh-key:
+    description: "Generate a new SSH keypair for this unit. This will replace any existing previously generated keypair."
+verify-ssh-credentials:
+    description: "Verify that this unit can authenticate with server specified by ssh-hostname and ssh-username."
+get-ssh-public-key:
+    description: "Get the public SSH key for this unit."

--- a/actions/generate-ssh-key
+++ b/actions/generate-ssh-key
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+##
+# Copyright 2016 Canonical Ltd.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+##
+import sys
+sys.path.append('lib')
+
+from charms.reactive import main
+from charms.reactive import set_state
+from charmhelpers.core.hookenv import action_fail, action_name
+
+"""
+`set_state` only works here because it's flushed to disk inside the `main()`
+loop. remove_state will need to be called inside the action method.
+"""
+set_state('actions.{}'.format(action_name()))
+
+try:
+    main()
+except Exception as e:
+    action_fail(repr(e))

--- a/actions/get-ssh-public-key
+++ b/actions/get-ssh-public-key
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+##
+# Copyright 2016 Canonical Ltd.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+##
+import sys
+sys.path.append('lib')
+
+from charms.reactive import main
+from charms.reactive import set_state
+from charmhelpers.core.hookenv import action_fail, action_name
+
+"""
+`set_state` only works here because it's flushed to disk inside the `main()`
+loop. remove_state will need to be called inside the action method.
+"""
+set_state('actions.{}'.format(action_name()))
+
+try:
+    main()
+except Exception as e:
+    action_fail(repr(e))

--- a/actions/run
+++ b/actions/run
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+##
+# Copyright 2016 Canonical Ltd.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+##
 import sys
 sys.path.append('lib')
 

--- a/actions/verify-ssh-credentials
+++ b/actions/verify-ssh-credentials
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+##
+# Copyright 2016 Canonical Ltd.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+##
+import sys
+sys.path.append('lib')
+
+from charms.reactive import main
+from charms.reactive import set_state
+from charmhelpers.core.hookenv import action_fail, action_name
+
+"""
+`set_state` only works here because it's flushed to disk inside the `main()`
+loop. remove_state will need to be called inside the action method.
+"""
+set_state('actions.{}'.format(action_name()))
+
+try:
+    main()
+except Exception as e:
+    action_fail(repr(e))

--- a/config.yaml
+++ b/config.yaml
@@ -1,17 +1,46 @@
+##
+# Copyright 2016 Canonical Ltd.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+##
+
 options:
-  ssh-hostname:
-    type: string
-    default: ""
-    description: "The hostname or IP address of the machine to"
-  ssh-username:
-    type: string
-    default: ""
-    description: "The username to login as."
-  ssh-password:
-    type: string
-    default: ""
-    description: "The password used to authenticate."
-  ssh-private-key:
-      type: string
-      default: ""
-      description: "The private ssh key to be used to authenticate."
+    ssh-hostname:
+        type: string
+        default: ""
+        description: "The hostname or IP address of the machine to"
+    ssh-username:
+        type: string
+        default: ""
+        description: "The username to login as."
+    ssh-password:
+        type: string
+        default: ""
+        description: "The password used to authenticate."
+    ssh-private-key:
+        type: string
+        default: ""
+        description: "DEPRECATED. The private ssh key to be used to authenticate."
+    ssh-public-key:
+        type: string
+        default: ""
+        description: "The public key of this unit."
+    ssh-key-type:
+        type: string
+        default: "rsa"
+        description: "The type of encryption to use for the SSH key."
+    ssh-key-bits:
+        type: int
+        default: 4096
+        description: "The number of bits to use for the SSH key."

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,1 +1,18 @@
+##
+# Copyright 2016 Canonical Ltd.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+##
+
 includes: ['layer:basic']  # if you use any interfaces, add them here

--- a/lib/charms/__init__.py
+++ b/lib/charms/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from . import sshproxy

--- a/lib/charms/sshproxy.py
+++ b/lib/charms/sshproxy.py
@@ -1,8 +1,27 @@
+"""Module to help with executing commands over SSH."""
+##
+# Copyright 2016 Canonical Ltd.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+##
+
 from charmhelpers.core.hookenv import (
     config,
 )
 import io
 import paramiko
+import os
 
 from subprocess import (
     Popen,
@@ -11,21 +30,10 @@ from subprocess import (
 )
 
 
-def _run(cmd, env=None):
-    """ Run a command, either on the local machine or remotely via SSH. """
+def run_local(cmd, env=None):
+    """Run a command locally."""
     if isinstance(cmd, str):
         cmd = cmd.split(' ') if ' ' in cmd else [cmd]
-
-    cfg = config()
-    if all(k in cfg for k in ['ssh-hostname', 'ssh-username',
-                              'ssh-password', 'ssh-private-key']):
-        host = cfg['ssh-hostname']
-        user = cfg['ssh-username']
-        passwd = cfg['ssh-password']
-        key = cfg['ssh-private-key']
-
-        if host and user and (passwd or key):
-            return ssh(cmd, host, user, passwd, key)
 
     p = Popen(cmd,
               env=env,
@@ -41,16 +49,41 @@ def _run(cmd, env=None):
     return (stdout.decode('utf-8').strip(), stderr.decode('utf-8').strip())
 
 
-def get_ssh_client(host, user, password=None, key=None):
-    """Return a connected Paramiko ssh object"""
+def _run(cmd, env=None):
+    """Run a command, either on the local machine or remotely via SSH."""
+    if isinstance(cmd, str):
+        cmd = cmd.split(' ') if ' ' in cmd else [cmd]
+    cfg = config()
 
+    if all(k in cfg for k in ['ssh-hostname', 'ssh-username',
+                              'ssh-password', 'ssh-private-key']):
+        host = cfg['ssh-hostname']
+        user = cfg['ssh-username']
+        passwd = cfg['ssh-password']
+        key = cfg['ssh-private-key']  # DEPRECATED
+
+        if host and user:
+            return ssh(cmd, host, user, passwd, key)
+
+    return run_local(cmd, env)
+
+
+def get_ssh_client(host, user, password=None, key=None):
+    """Return a connected Paramiko ssh object."""
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
     pkey = None
+
+    # Check for the DEPRECATED private-key
     if key:
         f = io.StringIO(key)
         pkey = paramiko.RSAKey.from_private_key(f)
+    else:
+        # Otherwise, check for the auto-generated private key
+        if os.path.exists('/root/.ssh/id_juju_sshproxy'):
+            with open('/root/.ssh/id_juju_sshproxy', 'r') as f:
+                pkey = paramiko.RSAKey.from_private_key(f)
 
     ###########################################################################
     # There is a bug in some versions of OpenSSH 4.3 (CentOS/RHEL 5) where    #
@@ -72,15 +105,15 @@ def get_ssh_client(host, user, password=None, key=None):
             # Once more, with feeling
             client.connect(host, port=22, username=user,
                            password=password, pkey=pkey)
-            pass
         else:
-            raise paramiko.ssh_exception.SSHException(e)
+            # Reraise the original exception
+            raise e
 
     return client
 
 
 def sftp(local_file, remote_file, host, user, password=None, key=None):
-    """Copy a local file to a remote host"""
+    """Copy a local file to a remote host."""
     client = get_ssh_client(host, user, password, key)
 
     # Create an sftp connection from the underlying transport
@@ -90,7 +123,7 @@ def sftp(local_file, remote_file, host, user, password=None, key=None):
 
 
 def ssh(cmd, host, user, password=None, key=None):
-    """ Run an arbitrary command over SSH. """
+    """Run an arbitrary command over SSH."""
     client = get_ssh_client(host, user, password, key)
 
     cmds = ' '.join(cmd)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,3 +1,20 @@
+##
+# Copyright 2016 Canonical Ltd.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+##
+
 name: sshproxy
 summary: Layer to copy files to or run commands on a remote host over ssh
 maintainer: Adam Israel <adam.israel@canonical.com>

--- a/reactive/sshproxy.py
+++ b/reactive/sshproxy.py
@@ -134,7 +134,7 @@ def verify_ssh_credentials():
     """
     try:
         cfg = config()
-        if all(k in cfg for k in ['ssh-hostname', 'ssh-username']):
+        if len(cfg['ssh-hostname']) and len(cfg['ssh-username']):
             cmd = 'hostname'
             output, err = charms.sshproxy._run(cmd)
 

--- a/reactive/sshproxy.py
+++ b/reactive/sshproxy.py
@@ -1,3 +1,20 @@
+##
+# Copyright 2016 Canonical Ltd.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+##
+
 from charmhelpers.core.hookenv import (
     action_fail,
     action_get,
@@ -8,14 +25,19 @@ from charms.reactive import (
     remove_state,
     set_state,
     when,
+    when_not,
 )
 import charms.sshproxy
+import os
+import paramiko
 import subprocess
 
 
 @when('config.changed')
 def ssh_configured():
-    """ Checks to see if the charm is configured with SSH credentials. If so,
+    """Check if charm is properly configured.
+
+    Check to see if the charm is configured with SSH credentials. If so,
     set a state flag that can be used to execute ssh-only actions.
 
     For example:
@@ -36,9 +58,116 @@ def ssh_configured():
         remove_state('sshproxy.configured')
 
 
+def generate_ssh_key():
+    """Generate a new 4096-bit rsa keypair.
+
+    If there is an existing keypair for this unit, it will be overwritten.
+    """
+    cfg = config()
+    if all(k in cfg for k in ['ssh-key-type', 'ssh-key-bits']):
+        keytype = cfg['ssh-key-type']
+        bits = str(cfg['ssh-key-bits'])
+        privatekey = '/root/.ssh/id_juju_sshproxy'
+        publickey = "{}.pub".format(privatekey)
+
+        if os.path.exists(privatekey):
+            os.remove(privatekey)
+        if os.path.exists(publickey):
+            os.remove(publickey)
+
+        cmd = "ssh-keygen -t {} -b {} -N '' -f {}".format(
+            keytype,
+            bits,
+            privatekey
+        )
+
+        output, err = charms.sshproxy.run_local([cmd])
+        if len(err) == 0:
+            return True
+    return False
+
+
+@when('actions.generate-ssh-key')
+def action_generate_ssh_key():
+    """Generate a new 4096-bit rsa keypair.
+
+    If there is an existing keypair for this unit, it will be overwritten.
+    """
+    try:
+        if not generate_ssh_key():
+            action_fail('Unable to generate ssh key.')
+    except subprocess.CalledProcessError as e:
+        action_fail('Command failed: %s (%s)' %
+                    (' '.join(e.cmd), str(e.output)))
+    finally:
+        remove_state('actions.generate-ssh-key')
+
+
+def get_ssh_public_key():
+    """Get the public SSH key of this unit."""
+    publickey_path = '/root/.ssh/id_juju_sshproxy.pub'
+    publickey = None
+    if os.path.exists(publickey_path):
+        with open(publickey_path, 'r') as f:
+            publickey = f.read()
+
+    return publickey
+
+
+@when('actions.get-ssh-public-key')
+def action_get_ssh_public_key():
+    """Get the public SSH key of this unit."""
+    try:
+        action_set({'pubkey': get_ssh_public_key()})
+    except subprocess.CalledProcessError as e:
+        action_fail('Command failed: %s (%s)' %
+                    (' '.join(e.cmd), str(e.output)))
+    finally:
+        remove_state('actions.get-ssh-public-key')
+
+
+@when('actions.verify-ssh-credentials')
+def verify_ssh_credentials():
+    """Verify the ssh credentials have been installed to the VNF.
+
+    Attempts to run a stock command - `hostname` on the remote host.
+    """
+    try:
+        cfg = config()
+        if all(k in cfg for k in ['ssh-hostname', 'ssh-username']):
+            cmd = 'hostname'
+            output, err = charms.sshproxy._run(cmd)
+
+            if len(err):
+                action_fail("Command '{}' returned error code {}".format(
+                    cmd,
+                    err,
+                ))
+            else:
+                action_set({'output': output})
+        else:
+            action_fail('Invalid SSH credentials.')
+    except subprocess.CalledProcessError as e:
+        action_fail('Command failed: %s (%s)' %
+                    (' '.join(e.cmd), str(e.output)))
+    except paramiko.ssh_exception.AuthenticationException as e:
+        action_fail('Authentication failed.')
+        pass
+    except paramiko.ssh_exception.BadAuthenticationType as e:
+        action_fail('{}'.format(e.explanation))
+    except paramiko.ssh_exception.BadHostKeyException as e:
+        action_fail('Host key mismatch: expected {} but got {}.'.format(
+            e.expected_key,
+            e.got_key,
+        ))
+    finally:
+        remove_state('actions.verify-ssh-credentials')
+
+
 @when('actions.run')
 def run_command():
-    """
+    """Run an arbitrary command.
+
     Run an arbitrary command, either locally or over SSH with the configured
     credentials.
     """
@@ -54,3 +183,10 @@ def run_command():
                     (' '.join(e.cmd), str(e.output)))
     finally:
         remove_state('actions.run')
+
+
+@when_not('sshproxy.installed')
+def install_vnf_ubuntu_proxy():
+    """Install and Configure SSH Proxy."""
+    generate_ssh_key()
+    set_state('sshproxy.installed')

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,18 @@
+##
+# Copyright 2016 Canonical Ltd.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+##
+
 paramiko>=1.16.0,<1.17


### PR DESCRIPTION
This PR adds secure key management, by generating a ssh keypair on installation or demand (via action), deprecating the usage of the ssh-private-key config setting, as it is inherently insecure by storing the private key in plaintext, readable by anyone with access to the Juju controller.